### PR TITLE
fix: 修复复制链接功能和日历热力图的 bug

### DIFF
--- a/web/src/components/MemoActionMenu/hooks.ts
+++ b/web/src/components/MemoActionMenu/hooks.ts
@@ -82,9 +82,11 @@ export const useMemoActionHandlers = ({ memo, onEdit, setDeleteDialogOpen }: Use
 
   const handleCopyLink = useCallback(() => {
     let host = profile.instanceUrl;
-    if (host === "") {
+    if (!host) {
       host = window.location.origin;
     }
+    // 去除尾部斜杠，避免双斜杠
+    host = host.replace(/\/+$/, "");
     copy(`${host}/${memo.name}`);
     toast.success(t("message.succeed-copy-link"));
   }, [memo.name, t, profile.instanceUrl]);

--- a/worker/src/routes/users.ts
+++ b/worker/src/routes/users.ts
@@ -154,7 +154,7 @@ userRoutes.get("/:username/stats", authOptional, async (c) => {
     tagCount: tagCounts,
     memoTypeStats: { linkCount, codeCount, todoCount, undoCount },
     pinnedMemos,
-    memoDisplayTimestamps: memos.map((m) => m.created_ts),
+    memoCreatedTimestamps: memos.map((m) => ({ seconds: m.created_ts, nanos: 0 })),
   };
 
   if (scope !== "owner") {


### PR DESCRIPTION
## 修复内容

### 1. 修复复制链接功能显示 undefined 的 bug

**问题**：复制链接功能显示为 `undefined/memos/285c714a1e5743cd900d7a`

**根本原因**：`profile.instanceUrl` 是 `undefined`（不是空字符串），导致 `undefined === ""` 为 `false`

**解决方案**：将 `if (host === "")` 改为 `if (!host)`，并添加尾部斜杠处理

**修改文件**：`web/src/components/MemoActionMenu/hooks.ts`

### 2. 修复日历热力图显示无数据的 bug

**问题**：日历热力图（Activity Calendar）显示无数据

**根本原因**：后端返回的字段名和格式与前端 protobuf 定义不一致
- 字段名：`memoDisplayTimestamps` vs `memoCreatedTimestamps`
- 数据格式：数字 vs `{ seconds, nanos }` 对象

**解决方案**：修改后端 API 返回的数据格式，与前端 protobuf 定义对齐

**修改文件**：`worker/src/routes/users.ts`