### PR TITLE
fix: 修复任务列表长链接换行异常

### DIFF
--- a/web/src/components/MemoContent/markdown/List.tsx
+++ b/web/src/components/MemoContent/markdown/List.tsx
@@ -1,7 +1,64 @@
+import { Children, cloneElement, isValidElement, type ReactElement, type ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { TASK_LIST_CLASS, TASK_LIST_ITEM_CLASS } from "../constants";
 import { NestedMarkdownRenderContext } from "../MarkdownRenderContext";
 import type { ReactMarkdownProps } from "./types";
+
+interface TaskListChildProps {
+  children?: ReactNode;
+  node?: {
+    tagName?: string;
+    properties?: {
+      type?: unknown;
+    };
+  };
+  type?: string;
+}
+
+const isCheckboxInput = (child: ReactNode): child is ReactElement<TaskListChildProps> => {
+  return (
+    isValidElement<TaskListChildProps>(child) && (child.props.type === "checkbox" || child.props.node?.properties?.type === "checkbox")
+  );
+};
+
+const isParagraphElement = (child: ReactNode): child is ReactElement<TaskListChildProps> => {
+  return isValidElement<TaskListChildProps>(child) && (child.type === "p" || child.props.node?.tagName === "p");
+};
+
+const splitTaskListItemChildren = (children: ReactNode) => {
+  let checkbox: ReactNode;
+  const content: ReactNode[] = [];
+
+  Children.toArray(children).forEach((child) => {
+    if (!checkbox && isCheckboxInput(child)) {
+      checkbox = child;
+      return;
+    }
+
+    if (!checkbox && isParagraphElement(child)) {
+      const paragraphChildren: ReactNode[] = [];
+
+      Children.toArray(child.props.children).forEach((paragraphChild) => {
+        if (!checkbox && isCheckboxInput(paragraphChild)) {
+          checkbox = paragraphChild;
+          return;
+        }
+        paragraphChildren.push(paragraphChild);
+      });
+
+      if (checkbox) {
+        if (paragraphChildren.length > 0) {
+          content.push(cloneElement(child, undefined, ...paragraphChildren));
+        }
+        return;
+      }
+    }
+
+    content.push(child);
+  });
+
+  return { checkbox, content };
+};
 
 interface ListProps extends React.HTMLAttributes<HTMLUListElement | HTMLOListElement>, ReactMarkdownProps {
   ordered?: boolean;
@@ -46,17 +103,20 @@ export const ListItem = ({ children, className, node: _node, ...domProps }: List
   const isTaskListItem = className?.includes(TASK_LIST_ITEM_CLASS);
 
   if (isTaskListItem) {
+    const { checkbox, content } = splitTaskListItemChildren(children);
+
     return (
       <li
         className={cn(
-          "mt-0.5 leading-6 list-none grid grid-cols-[auto_1fr] items-start gap-x-2 [&>[data-slot=checkbox]]:mt-1",
-          "[&>ul]:col-start-2 [&>ul]:col-span-1 [&>ol]:col-start-2 [&>ol]:col-span-1",
-          "[&>p:first-child]:contents [&>p:not(:first-child)]:col-start-2 [&>p:not(:first-child)]:col-span-1",
+          "mt-0.5 min-w-0 leading-6 list-none grid grid-cols-[auto_minmax(0,1fr)] items-start gap-x-2 [&>[data-slot=checkbox]]:mt-1",
           className,
         )}
         {...domProps}
       >
-        <NestedMarkdownRenderContext>{children}</NestedMarkdownRenderContext>
+        <NestedMarkdownRenderContext>
+          {checkbox}
+          <div className="min-w-0 [overflow-wrap:anywhere] [&>*:last-child]:mb-0">{content}</div>
+        </NestedMarkdownRenderContext>
       </li>
     );
   }


### PR DESCRIPTION
## 修复内容

### 修复任务列表中长链接换行表现与原版 Memos 不一致的问题

**问题**：主页和浏览页面的任务列表中，长链接不能像原版 Memos 一样正常收缩和换行，部分内容会出现换行位置异常或撑宽卡片。

**根本原因**：任务列表使用 `grid-cols-[auto_1fr]`，并将 checkbox 和正文子节点直接放入 Grid。`1fr` 内容列仍受固有最小宽度约束，且正文缺少 `min-w-0` 和 `overflow-wrap:anywhere`，导致连续 URL 无法在可用宽度内断行。

**解决方案**：与 Memos v0.29.1 的任务列表实现对齐：

- 从 React 子节点中拆分 checkbox 与正文内容
- 将内容列改为 `minmax(0,1fr)`
- 为列表项和正文容器增加 `min-w-0`
- 为正文增加 `overflow-wrap:anywhere`
- 保持嵌套列表和多段任务内容与 checkbox 正确对齐

**修改文件**：`web/src/components/MemoContent/markdown/List.tsx`

## 验证

- `npm run build:web` 构建通过
- Wrangler 部署预检通过
- 已确认生产 CSS 包含新的断行与 Grid 规则
- 生产健康检查正常
